### PR TITLE
Bug fixes and improvements to teardown and setup for docker-desktop and minikube on Windows

### DIFF
--- a/scripts/setup-docker-desktop.ps1
+++ b/scripts/setup-docker-desktop.ps1
@@ -163,7 +163,12 @@ function Test-Prerequisites {
 
 # ── Switch kubectl context ────────────────────────────────────────────────────
 function Set-KubeContext {
-    $current = (kubectl config current-context 2>$null).Trim()
+    $current = kubectl config current-context 2>$null | Select-Object -First 1
+    if ($null -eq $current) {
+        $current = ''
+    } else {
+        $current = $current.ToString().Trim()
+    }
     if ($current -eq $KubeContext) {
         Write-Ok "kubectl context is already '$KubeContext'"
         return

--- a/scripts/setup-docker-desktop.ps1
+++ b/scripts/setup-docker-desktop.ps1
@@ -335,6 +335,9 @@ function Start-Keycloak {
     Write-Log "Waiting for Keycloak server pod..."
     Invoke-Native kubectl @('wait', '--for=condition=ready', 'pod', '-l', 'app=keycloak', '-n', $Namespace, '--timeout=300s')
 
+    Write-Log "Waiting for Keycloak realm import to complete..."
+    Invoke-Native kubectl @('wait', '--for=condition=Done', 'keycloakrealmimport/csoc-realm', '-n', $Namespace, '--timeout=300s')
+
     Write-Ok "Keycloak is ready"
     Set-KeycloakHosts
 }
@@ -488,6 +491,11 @@ function Remove-Setup {
 
         # Optionally remove Keycloak + CNPG
         if ($Script:InstallKeycloak) {
+            # Always remove script-managed config resources (no owner references, no user data)
+            kubectl delete secret keycloak-admin-credentials -n $Namespace --ignore-not-found=true 2>$null
+            kubectl delete ingress keycloak-ingress -n $Namespace --ignore-not-found=true 2>$null
+            kubectl delete svc keycloak-http -n $Namespace --ignore-not-found=true 2>$null
+
             $kcExists = kubectl get keycloak keycloak -n $Namespace 2>$null
             if ($kcExists) {
                 $ans = Read-Host "Remove Keycloak + CloudNativePG resources? [y/N]"
@@ -510,8 +518,13 @@ function Remove-Setup {
             $ans = Read-Host "Remove Keycloak operator too? [y/N]"
             if ($ans -match '^[Yy]$') {
                 Write-Log "Removing Keycloak operator..."
-                kubectl delete deployment/keycloak-operator -n $Namespace --ignore-not-found=true 2>$null
-                kubectl delete crds keycloaks.k8s.keycloak.org keycloakrealmimports.k8s.keycloak.org --ignore-not-found=true 2>$null
+                $kcVersion = '26.6.1'
+                kubectl delete -n $Namespace -f "https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/$kcVersion/kubernetes/kubernetes.yml" `
+                    --ignore-not-found=true 2>$null
+                kubectl delete -f "https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/$kcVersion/kubernetes/keycloaks.k8s.keycloak.org-v1.yml" `
+                    --ignore-not-found=true 2>$null
+                kubectl delete -f "https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/$kcVersion/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml" `
+                    --ignore-not-found=true 2>$null
                 Write-Ok "Keycloak operator removed"
             }
         }

--- a/scripts/setup-minikube.ps1
+++ b/scripts/setup-minikube.ps1
@@ -323,6 +323,9 @@ function Start-Keycloak {
     Write-Log "Waiting for Keycloak server pod..."
     Invoke-Native kubectl @('wait', '--for=condition=ready', 'pod', '-l', 'app=keycloak', '-n', $Namespace, '--timeout=300s')
 
+    Write-Log "Waiting for Keycloak realm import to complete..."
+    Invoke-Native kubectl @('wait', '--for=condition=Done', 'keycloakrealmimport/csoc-realm', '-n', $Namespace, '--timeout=300s')
+
     Write-Ok "Keycloak is ready"
     Set-KeycloakHosts
 }
@@ -483,6 +486,11 @@ function Remove-Setup {
 
         # Optionally remove Keycloak + CNPG
         if ($Script:InstallKeycloak) {
+            # Always remove script-managed config resources (no owner references, no user data)
+            kubectl delete secret keycloak-admin-credentials -n $Namespace --ignore-not-found=true 2>$null
+            kubectl delete ingress keycloak-ingress -n $Namespace --ignore-not-found=true 2>$null
+            kubectl delete svc keycloak-http -n $Namespace --ignore-not-found=true 2>$null
+
             $kcExists = kubectl get keycloak keycloak -n $Namespace 2>$null
             if ($kcExists) {
                 $ans = Read-Host "Remove Keycloak + CloudNativePG resources? [y/N]"
@@ -505,8 +513,13 @@ function Remove-Setup {
             $ans = Read-Host "Remove Keycloak operator too? [y/N]"
             if ($ans -match '^[Yy]$') {
                 Write-Log "Removing Keycloak operator..."
-                kubectl delete deployment/keycloak-operator -n $Namespace --ignore-not-found=true 2>$null
-                kubectl delete crds keycloaks.k8s.keycloak.org keycloakrealmimports.k8s.keycloak.org --ignore-not-found=true 2>$null
+                $kcVersion = '26.6.1'
+                kubectl delete -n $Namespace -f "https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/$kcVersion/kubernetes/kubernetes.yml" `
+                    --ignore-not-found=true 2>$null
+                kubectl delete -f "https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/$kcVersion/kubernetes/keycloaks.k8s.keycloak.org-v1.yml" `
+                    --ignore-not-found=true 2>$null
+                kubectl delete -f "https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/$kcVersion/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml" `
+                    --ignore-not-found=true 2>$null
                 Write-Ok "Keycloak operator removed"
             }
         }

--- a/scripts/setup-minikube.ps1
+++ b/scripts/setup-minikube.ps1
@@ -139,27 +139,30 @@ function Test-Prerequisites {
 
 # ── Minikube start ────────────────────────────────────────────────────────────
 function Start-MinikubeCluster {
-    $statusOut = minikube status -p $Script:MinikubeProfile 2>$null
-    if ($statusOut -match 'Running') {
-        Write-Warn "Minikube already running, skipping start"
-        minikube -p $Script:MinikubeProfile update-context 2>$null
-        return
+    $statusOut = minikube status -p $Script:MinikubeProfile --format='{{.Host}}' 2>$null
+    if ($statusOut -ne 'Running') {
+        Write-Log "Starting Minikube (profile: $($Script:MinikubeProfile))..."
+        # Note: --driver=docker requires Docker Desktop running on Windows.
+        # Alternatively use --driver=hyperv if Hyper-V is preferred.
+        Invoke-Native minikube @(
+            'start',
+            '-p', $Script:MinikubeProfile,
+            '--driver=docker',
+            '--cpus=4',
+            '--memory=8192',
+            '--disk-size=40g',
+            '--kubernetes-version=v1.35',
+            '--container-runtime=docker'
+        )
+    }
+    else {
+        Write-Log "Minikube already running, skipping start"
     }
 
-    Write-Log "Starting Minikube (profile: $($Script:MinikubeProfile))..."
-    # Note: --driver=docker requires Docker Desktop running on Windows.
-    # Alternatively use --driver=hyperv if Hyper-V is preferred.
-    Invoke-Native minikube @(
-        'start',
-        '-p', $Script:MinikubeProfile,
-        '--driver=docker',
-        '--cpus=4',
-        '--memory=8192',
-        '--disk-size=40g',
-        '--kubernetes-version=v1.35',
-        '--container-runtime=docker'
-    )
-
+    # Switch context
+    Write-Log "Switching context..."
+    minikube -p $Script:MinikubeProfile update-context 2>$null
+    
     # Enable required addons
     Write-Log "Enabling addons..."
     minikube addons enable metrics-server -p $Script:MinikubeProfile 2>$null
@@ -233,13 +236,15 @@ function Remove-HostsEntry {
 }
 
 function Set-CSOCHosts {
-    $ip = (minikube ip -p $Script:MinikubeProfile).Trim()
+    # For simplicity, point both the main hostname and the Gen3 hostname to localhost since Minikube's ingress will be accessible via localhost (with minikube tunnel running). 
+    $ip = "127.0.0.1"
     Set-HostsEntry -HostName $Script:Hostname     -IP $ip
     Set-HostsEntry -HostName $Script:Gen3Hostname -IP $ip
 }
 
 function Set-KeycloakHosts {
-    $ip = (minikube ip -p $Script:MinikubeProfile).Trim()
+    # For simplicity, point the Keycloak hostname to localhost since the keycloak-http service will be accessible via localhost (with minikube tunnel running).
+    $ip = "127.0.0.1"
     Set-HostsEntry -HostName $Script:KeycloakHostname -IP $ip
 }
 
@@ -664,7 +669,7 @@ function Main {
 
         if (-not $ClusterOnly) {
             Write-Host ""
-            Write-Ok "Setup complete! Open http://$($Script:Hostname) in your browser"
+            Write-Ok "Setup complete! Run minikube tunnel in a separate terminal and then open http://$($Script:Hostname) in your browser"
         } else {
             Write-Host ""
             Write-Ok "Minikube ready. Deploy with:  .\setup-minikube.ps1 -Namespace $Namespace"


### PR DESCRIPTION
This pull request improves the reliability and consistency of the Kubernetes setup and teardown PowerShell scripts for both Docker Desktop and Minikube environments on Windows.

**Keycloak setup and teardown improvements:**

* Added explicit waits for Keycloak realm import completion during setup to ensure Keycloak is fully ready before proceeding.
* Enhanced Keycloak cleanup by always removing script-managed resources (secrets, ingress, service) during teardown, reducing leftover artifacts.
* Improved Keycloak operator removal by deleting resources using versioned manifests from the Keycloak repository, ensuring all related CRDs and deployments are properly cleaned up.

**Cluster context and status detection:**

* Made kubectl context switching more robust by handling cases where the current context is null, preventing errors if no context is set.
* Improved Minikube cluster status detection by using the `--format` flag for more reliable parsing, and always updating the context after checking status.

**Host resolution and user guidance:**

* Simplified host entries for Minikube by always pointing service hostnames to `127.0.0.1`, reflecting the use of `minikube tunnel` for local access.
* Updated user instructions to explicitly remind users to run `minikube tunnel` before accessing services in the browser.